### PR TITLE
feat: Menambahkan error handler global untuk error 

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,7 +1,9 @@
 const express = require("express");
 const cors = require("cors");
 const dotenv = require("dotenv");
+const methodOverride = require("method-override");
 const routes = require("./routers");
+const { unhandledErrorHandler } = require("./middleware/unhandledErrorHandler");
 
 dotenv.config();
 require("./db/mongoose");
@@ -10,6 +12,10 @@ const app = express();
 
 app.use(express.json());
 app.use(cors());
+
 app.use("/api", routes);
 
 app.listen(process.env.PORT, () => console.log("Running..."));
+
+app.use(methodOverride());
+app.use(unhandledErrorHandler);

--- a/constant/errorTokens.js
+++ b/constant/errorTokens.js
@@ -1,0 +1,9 @@
+const INTERNAL_SERVER_ERROR = "InternalServerError";
+
+const ErrorTokens = Object.freeze({
+  INTERNAL_SERVER_ERROR,
+});
+
+module.exports = {
+  ErrorTokens,
+};

--- a/constant/httpStatusCodes.js
+++ b/constant/httpStatusCodes.js
@@ -1,0 +1,25 @@
+const OK = 200;
+const CREATED = 201;
+const NO_CONTENT = 204;
+
+const BAD_REQUEST = 400;
+const UNAUTHORIZED = 401;
+const FORBIDDEN = 403;
+const NOT_FOUND = 404;
+const UNPROCESSABLE_ENTITY = 422;
+
+const INTERNAL_SERVER_ERROR = 500;
+
+const HttpStatusCode = Object.freeze({
+  OK,
+  CREATED,
+  NO_CONTENT,
+  BAD_REQUEST,
+  UNAUTHORIZED,
+  FORBIDDEN,
+  NOT_FOUND,
+  UNPROCESSABLE_ENTITY,
+  INTERNAL_SERVER_ERROR,
+});
+
+module.exports = { HttpStatusCode };

--- a/middleware/unhandledErrorHandler.js
+++ b/middleware/unhandledErrorHandler.js
@@ -1,0 +1,14 @@
+const { ErrorTokens } = require("../constant/errorTokens");
+const { HttpStatusCode } = require("../constant/httpStatusCodes");
+
+function unhandledErrorHandler(err, req, res, next) {
+  console.log(err);
+
+  res.status(HttpStatusCode.INTERNAL_SERVER_ERROR);
+  res.send({
+    error: ErrorTokens.INTERNAL_SERVER_ERROR,
+    message: "Internal Server Error",
+  });
+}
+
+module.exports = { unhandledErrorHandler };

--- a/middleware/unhandledErrorHandler.js
+++ b/middleware/unhandledErrorHandler.js
@@ -4,7 +4,11 @@ const { HttpStatusCode } = require("../constant/httpStatusCodes");
 function unhandledErrorHandler(err, req, res, next) {
   console.log(err);
 
-  res.status(HttpStatusCode.INTERNAL_SERVER_ERROR);
+  if (res.headersSent) {
+    return next(err);
+  }
+
+  res.status(err.status || HttpStatusCode.INTERNAL_SERVER_ERROR);
   res.send({
     error: ErrorTokens.INTERNAL_SERVER_ERROR,
     message: "Internal Server Error",

--- a/package-lock.json
+++ b/package-lock.json
@@ -960,6 +960,27 @@
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
       "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E="
     },
+    "method-override": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/method-override/-/method-override-3.0.0.tgz",
+      "integrity": "sha512-IJ2NNN/mSl9w3kzWB92rcdHpz+HjkxhDJWNDBqSlas+zQdP8wBiJzITPg08M/k2uVvMow7Sk41atndNtt/PHSA==",
+      "requires": {
+        "debug": "3.1.0",
+        "methods": "~1.1.2",
+        "parseurl": "~1.3.2",
+        "vary": "~1.1.2"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
+      }
+    },
     "methods": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "dotenv": "^10.0.0",
     "express": "^4.17.1",
     "jsonwebtoken": "^8.5.1",
+    "method-override": "^3.0.0",
     "mongodb": "^4.2.0",
     "mongoose": "^6.0.13",
     "validator": "^13.7.0"


### PR DESCRIPTION
**Pekerjaan selesai**

- [x] Menambahkan error handler untuk menangkap error yang tidak terhandle sehingga
- [x] Menambahkan konstan HttpStatus

**Catatan**
Error yang berasal dari operasi asinkron tidak bisa tercover karena express tidak dapat menghandle operasi asinkron secara native. Opsi yang bisa dilakukan : 
1. migrate pakai koa / yang lain  
2. mengoverride tiap2 handler express agar bisa handle asinkron 
3. menambahkan try catch di setiap operasi asinkron